### PR TITLE
chore: upgrade to golang 1.14

### DIFF
--- a/.github/workflows/cicd-build.yml
+++ b/.github/workflows/cicd-build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.13
+          go-version: ^1.14
         id: go
 
       - name: Get dependencies

--- a/.github/workflows/cicd-release.yml
+++ b/.github/workflows/cicd-release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.13
+          go-version: ^1.14
         id: go
 
       - name: Get dependencies


### PR DESCRIPTION
I thought it would be better to use the latest golang version.

Signed-off-by: solidnerd <niclas@mietz.io>