### PR TITLE
Implement harbor_usergroup resource

### DIFF
--- a/docs/resources/harbor_usergroup.md
+++ b/docs/resources/harbor_usergroup.md
@@ -1,0 +1,34 @@
+# Resource: harbor_usergroup
+
+## Example Usage
+
+```hcl
+resource "harbor_usergroup" "developers" {
+    name = "developers"
+    type = "http"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the user group to be created.
+
+* `ldap_dn` - (Optional) The LDAP Group distingish name if `type` is `ldap`, defaults to `""`.
+
+* `type` - (Required) The group type: `ldap`, `http` or `oidc`.
+
+## Attributes Reference
+
+In addition to all arguments, the following attribute is exported:
+
+* `id` - The id of the group.
+
+## Import
+
+Harbor Usergroups can be imported using the `harbor_usergroup`, e.g.
+
+```sh
+terraform import harbor_usergroup.developers 5
+```

--- a/harbor/provider.go
+++ b/harbor/provider.go
@@ -53,6 +53,7 @@ func Provider() terraform.ResourceProvider {
 			"harbor_tasks":         resourceTasks(),
 			"harbor_label":         resourceLabel(),
 			"harbor_replication":   resourceReplication(),
+			"harbor_usergroup":     resourceUsergroup(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"harbor_project":  dataSourceProject(),

--- a/harbor/resource_usergroup.go
+++ b/harbor/resource_usergroup.go
@@ -1,0 +1,189 @@
+package harbor
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/nolte/terraform-provider-harbor/gen/harborctl/client"
+	"github.com/nolte/terraform-provider-harbor/gen/harborctl/client/products"
+	"github.com/nolte/terraform-provider-harbor/gen/harborctl/models"
+)
+
+var groupTypeName2Num = map[string]int64{
+	"ldap": 1,
+	"http": 2,
+	"oidc": 3,
+}
+
+var groupTypeNum2Name = map[int64]string{
+	1: "ldap",
+	2: "http",
+	3: "oidc",
+}
+
+func resourceUsergroup() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ldap_dn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+		Create: resourceUsergroupCreate,
+		Read:   resourceUsergroupRead,
+		Update: resourceUsergroupUpdate,
+		Delete: resourceUsergroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}
+
+func getGroupTypeName(name string) (int64, error) {
+	if num, ok := groupTypeName2Num[name]; ok {
+		return num, nil
+	}
+	return 0, fmt.Errorf("group type \"%s\" is unknown", name)
+}
+
+func resourceUsergroupCreate(d *schema.ResourceData, m interface{}) error {
+	apiClient := m.(*client.Harbor)
+	usergroupTypeNum, err := getGroupTypeName(d.Get("type").(string))
+	if err != nil {
+		return err
+	}
+
+	body := products.NewPostUsergroupsParams().WithUsergroup(&models.UserGroup{
+		GroupType:   usergroupTypeNum,
+		LdapGroupDn: d.Get("ldap_dn").(string),
+		GroupName:   d.Get("name").(string),
+	})
+
+	if _, err := apiClient.Products.PostUsergroups(body, nil); err != nil {
+		return err
+	}
+
+	usergroup, err := findUsergroupByName(d, m)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.Itoa(int(usergroup.ID)))
+
+	return resourceUsergroupRead(d, m)
+}
+
+func findUsergroupByName(d *schema.ResourceData, m interface{}) (*models.UserGroup, error) {
+	apiClient := m.(*client.Harbor)
+
+	if usergroupName, ok := d.GetOk("name"); ok {
+		query := products.NewGetUsergroupsParams()
+
+		resp, err := apiClient.Products.GetUsergroups(query, nil)
+		if err != nil {
+			d.SetId("")
+			return &models.UserGroup{}, err
+		}
+
+		for _, usergroup := range resp.Payload {
+			if usergroup.GroupName == usergroupName {
+				return usergroup, nil
+			}
+		}
+
+		return &models.UserGroup{}, fmt.Errorf("no usergroups with name %v", usergroupName)
+	}
+
+	return &models.UserGroup{}, fmt.Errorf("fail to lookup usergroup by Name")
+}
+
+func resourceUsergroupRead(d *schema.ResourceData, m interface{}) error {
+	apiClient := m.(*client.Harbor)
+
+	if usergroupID, err := strconv.ParseInt(d.Id(), 10, 64); err == nil {
+		query := products.NewGetUsergroupsGroupIDParams().WithGroupID(usergroupID)
+
+		resp, err := apiClient.Products.GetUsergroupsGroupID(query, nil)
+		if err != nil {
+			return err
+		}
+
+		if err := setUsergroupSchema(d, resp.Payload); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("fail to load the project")
+}
+
+func resourceUsergroupUpdate(d *schema.ResourceData, m interface{}) error {
+	apiClient := m.(*client.Harbor)
+
+	usergroupTypeNum, err := getGroupTypeName(d.Get("type").(string))
+	if err != nil {
+		return err
+	}
+
+	if usergroupID, err := strconv.ParseInt(d.Id(), 10, 64); err == nil {
+		body := products.NewPutUsergroupsGroupIDParams().WithUsergroup(&models.UserGroup{
+			GroupName:   d.Get("name").(string),
+			LdapGroupDn: d.Get("ldap_dn").(string),
+			GroupType:   usergroupTypeNum,
+		}).WithGroupID(usergroupID)
+
+		if _, err := apiClient.Products.PutUsergroupsGroupID(body, nil); err != nil {
+			return err
+		}
+
+		return resourceUsergroupRead(d, m)
+	}
+
+	return fmt.Errorf("Usergroup Id not a Integer")
+}
+
+func resourceUsergroupDelete(d *schema.ResourceData, m interface{}) error {
+	apiClient := m.(*client.Harbor)
+
+	if usergroupID, err := strconv.ParseInt(d.Id(), 10, 64); err == nil {
+		delete := products.NewDeleteUsergroupsGroupIDParams().WithGroupID(usergroupID)
+		if _, err := apiClient.Products.DeleteUsergroupsGroupID(delete, nil); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("Usergroup Id not a Integer")
+}
+
+func setUsergroupSchema(data *schema.ResourceData, usergroup *models.UserGroup) error {
+	data.SetId(strconv.Itoa(int(usergroup.ID)))
+
+	if err := data.Set("name", usergroup.GroupName); err != nil {
+		return err
+	}
+
+	if err := data.Set("ldap_dn", usergroup.LdapGroupDn); err != nil {
+		return err
+	}
+
+	usergroupTypeName := groupTypeNum2Name[usergroup.GroupType]
+	if err := data.Set("type", usergroupTypeName); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/harbor/resource_usergroup_test.go
+++ b/harbor/resource_usergroup_test.go
@@ -1,0 +1,108 @@
+package harbor_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/nolte/terraform-provider-harbor/gen/harborctl/client"
+	"github.com/nolte/terraform-provider-harbor/gen/harborctl/client/products"
+	"github.com/nolte/terraform-provider-harbor/gen/harborctl/models"
+)
+
+func init() {
+	resource.AddTestSweepers("resource_harbor_usergroup", &resource.Sweeper{
+		Name: "harbor_usergroup",
+	})
+}
+
+func TestAccHarborUsergroup_Basic(t *testing.T) {
+	var usergroup models.UserGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccHarborPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHarborCheckUsergroupResourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccHarborCheckUsergroupExists("harbor_usergroup.main", &usergroup),
+					resource.TestCheckResourceAttr(
+						"harbor_usergroup.main", "name", "acc-usergroup-test"),
+					resource.TestCheckResourceAttr(
+						"harbor_usergroup.main", "ldap_dn", "cn=testers,ou=groups,dc=example,dc=com"),
+					resource.TestCheckResourceAttr(
+						"harbor_usergroup.main", "type", "http"),
+				),
+			},
+			//			{
+			//				Config: testAccHarborCheckUsergroupLdapResourceConfig(),
+			//				Check: resource.ComposeTestCheckFunc(
+			//					testAccHarborCheckUsergroupExists("harbor_usergroup.main", &usergroup),
+			//					resource.TestCheckResourceAttr(
+			//						"harbor_usergroup.main", "name", "acc-usergroup-test-2"),
+			//					resource.TestCheckResourceAttr(
+			//						"harbor_usergroup.main", "ldap_dn", "cn=developers,ou=groups,dc=example,dc=com"),
+			//					resource.TestCheckResourceAttr(
+			//						"harbor_usergroup.main", "type", "http"),
+			//				),
+			//			},
+		},
+	})
+}
+
+func testAccHarborCheckUsergroupResourceConfig() string {
+	return `
+resource "harbor_usergroup" "main" {
+    name = "acc-usergroup-test"
+	ldap_dn = "cn=testers,ou=groups,dc=example,dc=com"
+    type = "http"
+}
+`
+}
+
+// Can't test LDAP type without an LDAP server or mock
+func testAccHarborCheckUsergroupLdapResourceConfig() string {
+	return `
+resource "harbor_usergroup" "main" {
+    name    = "acc-usergroup-test"
+	ldap_dn = "cn=developers,ou=groups,dc=example,dc=com"
+    type    = "http"
+}
+`
+}
+
+func testAccHarborCheckUsergroupExists(n string, usergroup *models.UserGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*client.Harbor)
+
+		if searchID, err := strconv.ParseInt(rs.Primary.ID, 10, 64); err == nil {
+			params := products.NewGetUsergroupsGroupIDParams().WithGroupID(searchID)
+
+			foundUsergroup, err := client.Products.GetUsergroupsGroupID(params, nil)
+			if err != nil {
+				return err
+			}
+
+			if foundUsergroup == nil {
+				return fmt.Errorf("Record not found")
+			}
+
+			*usergroup = *foundUsergroup.Payload
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
### Description

Implement `harbor_usergroup` resource binding to Harbor Usergroup operations.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

None

### Community Note
* did not find how to get test log (to make it available as a gist), the log output for this test is:
```
=== RUN   TestAccHarborUsergroup_Basic
--- PASS: TestAccHarborUsergroup_Basic (0.08s)
```
* acceptance test with `ldap_dn` fails (have to test it with a LDAP configuration and may be a LDAP mock or LDAP service for full integration), it is currently commented out. Any idea for this would be welcome.
* currently, the type content is checked at run, it would be great to implement static check for terraform validation (may be done later).