### PR TITLE
resource project_member: fix role name => id mapping

### DIFF
--- a/harbor/resource_project_member.go
+++ b/harbor/resource_project_member.go
@@ -13,17 +13,17 @@ import (
 
 var roleName2Id = map[string]int64{
 	"project_admin": 1,
-	"master":        2,
-	"developer":     3,
-	"guest":         4,
+	"developer":     2,
+	"guest":         3,
+	"master":        4,
 	"limited_guest": 5,
 }
 
 var roleId2Name = map[int64]string{
 	1: "project_admin",
-	2: "master",
-	3: "developer",
-	4: "guest",
+	2: "developer",
+	3: "guest",
+	4: "master",
 	5: "limited_guest",
 }
 


### PR DESCRIPTION


### Description

Fix the mapping "role name" to "role id" for the `project_member` resource.

Got the source of truth from https://github.com/goharbor/harbor/blob/master/src/portal/src/app/shared/shared.const.ts

btw, the role "master" will be renamed to "maintainer" in a future release.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

### Documentation

N/A

### References

https://github.com/goharbor/harbor/blob/master/src/portal/src/app/shared/shared.const.ts

### Community Note

Currently, I don't know how to maintain this mapping other than manually and watching to Harbor source code. It is documented (but not up to date) in the description of the `roleId` integer field but there is no reference structure for this mapping.

Without a source of truth given as parsable reference from Harbor, we cannot have any test to guaranty the mapping is not broken.