### PR TITLE
Fix example as well as typo

### DIFF
--- a/docs/resources/harbor_retention_policy.md
+++ b/docs/resources/harbor_retention_policy.md
@@ -16,13 +16,20 @@ resource "harbor_retention_policy" "cleanup" {
 
     rule {
         template = "always"
-	tag_selectors {
-	    decoration = "matches"
-	    pattern    = "master"
-	    extras     = jsonencode({
+        tag_selectors {
+            decoration = "matches"
+            pattern    = "master"
+            extras     = jsonencode({
                 untagged: false
             })
-	}
+        }
+        scope_selectors {
+            repository {
+                kind       = "doublestar"
+                decoration = "repoMatches"
+                pattern    = "**"
+            }
+        }
     }
 
     rule {
@@ -91,7 +98,7 @@ The following arguments are supported:
 
   * `latestPushedK`: (retain) the most recently pushed # artifacts
 
-  * `latestPulledK`: (retain) the most recently pulled # artifacts
+  * `latestPulledN`: (retain) the most recently pulled # artifacts
 
   * `nDaysSinceLastPush`: (retain) the artifacts pushed with the last # days
 


### PR DESCRIPTION


### Description
Fix retention policy documentation: example and typo:

- one rule is the example was missing the `scopeSelectors` subfield
- typo "latestPulledK" => "latestPulledN" (see https://github.com/goharbor/harbor/blob/master/src/core/api/retention.go for reference)
- fix indentation (mixed tabs + whitespaces => converting to whitespaces)

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

<!---
More informations about the Documentation process can be found at
https://nolte.github.io/terraform-provider-harbor/guides/development/#docs
--->
### Documentation
- [ ] Have you create or updated the provider documentation at ``./docs``?
  - [ ] If **new** resources or datasource documentation happen, did you add this to the `mkdocs.yml` configuration?

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
