### PR TITLE
role_id must be role in the example.

### DIFF
--- a/docs/resources/harbor_project_member.md
+++ b/docs/resources/harbor_project_member.md
@@ -14,7 +14,7 @@ resource "harbor_usergroup" "developers" {
 
 resource "harbor_project_member" "developers_main" {
     project_id = harbor_project.main.id
-    role_id    = "guest"
+    role       = "guest"
     group_type = "http"
     group_name = harbor_usergroup.developers.name
 }


### PR DESCRIPTION
### Description

Fix project member documentation typo: `role_id` must be `role` in the example.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

<!---
More informations about the Documentation process can be found at
https://nolte.github.io/terraform-provider-harbor/guides/development/#docs
--->
### Documentation
- [ ] Have you create or updated the provider documentation at ``./docs``?
  - [ ] If **new** resources or datasource documentation happen, did you add this to the `mkdocs.yml` configuration?

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
