### PR TITLE
add harbor v2.0.1 for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,13 @@ e2e_prepare:
 
 
 e2e_prepare_harbor_v1:
-	scripts/tst-01-prepare-harbor.sh "172-17-0-1.sslip.io" "1.3.2"
+	scripts/tst-01-prepare-harbor.sh "172-17-0-1.sslip.io" "1.3.4"
 
 e2e_prepare_harbor_v2:
 	scripts/tst-01-prepare-harbor.sh "172-17-0-1.sslip.io" "1.4.0"
+
+e2e_prepare_harbor_v2_1:
+	scripts/tst-01-prepare-harbor.sh "172-17-0-1.sslip.io" "1.4.1"
 
 e2e_clean_cluster:
 	kind delete cluster || true

--- a/scripts/swagger-specs/v2-swagger-original.json
+++ b/scripts/swagger-specs/v2-swagger-original.json
@@ -5300,10 +5300,6 @@
                     "description": "The client id of the OIDC.",
                     "$ref": "#/definitions/StringConfigItem"
                 },
-                "oidc_groups_claim": {
-                    "description": "The client Scope Claim of the OIDC.",
-                    "$ref": "#/definitions/StringConfigItem"
-                },
                 "ldap_group_base_dn": {
                     "description": "The base DN to search LDAP group.",
                     "$ref": "#/definitions/StringConfigItem"
@@ -6818,10 +6814,6 @@
                 "prevent_vul": {
                     "type": "string",
                     "description": "Whether prevent the vulnerable images from running. The valid values are \"true\", \"false\"."
-                },
-                "retention_id": {
-                    "type": "string",
-                    "description": "Retention policy id associated to the project if any"
                 }
             }
         },
@@ -7503,10 +7495,6 @@
                     "type": "string",
                     "description": "The username for authenticate against SMTP server."
                 },
-                "email_password": {
-                    "type": "string",
-                    "description": "The password for authenticate against SMTP server."
-                },
                 "oidc_endpoint": {
                     "type": "string",
                     "description": "The URL of an OIDC-complaint server, must start with 'https://'."
@@ -7514,10 +7502,6 @@
                 "oidc_client_secret": {
                     "type": "string",
                     "description": "The client secret of the OIDC."
-                },
-                "oidc_groups_claim": {
-                    "description": "The client Scope Claim of the OIDC.",
-                    "type": "string"
                 },
                 "ldap_scope": {
                     "type": "integer",


### PR DESCRIPTION
### Description

Adding deployment for Harbor Helm Chart Version [v1.4.1](https://github.com/goharbor/harbor-helm/releases/tag/v1.4.1), for Testing Harbor Version `2.0.1`.

### Acceptance tests
- [X] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

<!---
More informations about the Documentation process can be found at
https://nolte.github.io/terraform-provider-harbor/guides/development/#docs
--->
### Documentation
- ~~[ ] Have you create or updated the provider documentation at ``./docs``?~~
  - ~~[ ] If **new** resources or datasource documentation happen, did you add this to the `mkdocs.yml` configuration?~~

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
