### PR TITLE
Fix project resource import where autoscan is unknown / unset.

### DIFF
--- a/harbor/resource_project.go
+++ b/harbor/resource_project.go
@@ -156,13 +156,16 @@ func setProjectSchema(data *schema.ResourceData, project *models.Project) error 
 		return err
 	}
 
-	autoScan, err := strconv.ParseBool(project.Metadata.AutoScan)
-	if err != nil {
-		return err
-	}
+	// prevent errors where auto_scan is unset
+	if project.Metadata.AutoScan != "" {
+		autoScan, err := strconv.ParseBool(project.Metadata.AutoScan)
+		if err != nil {
+			return err
+		}
 
-	if err := data.Set("vulnerability_scanning", autoScan); err != nil {
-		return err
+		if err := data.Set("vulnerability_scanning", autoScan); err != nil {
+			return err
+		}
 	}
 
 	public, err := strconv.ParseBool(project.Metadata.Public)


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch?

<!---
More informations about the Documentation process can be found at
https://nolte.github.io/terraform-provider-harbor/guides/development/#docs
--->
### Documentation
- [x] Have you create or updated the provider documentation at ``./docs``?
  - ~[ ] If **new** resources or datasource documentation happen, did you add this to the `mkdocs.yml` configuration?~

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
