### PR TITLE
Add credentials to registry resource

### DIFF
--- a/documentation/provider_doc/resources/harbor_registry.mdpp
+++ b/documentation/provider_doc/resources/harbor_registry.mdpp
@@ -23,6 +23,12 @@ The following arguments are supported:
 
 * `insecure` - (Optional) Harbor ignores insecure external registry errors. Can be set to `true` or `false` (Default: `false`)
 
+* `access_key` - (Optional) The registry access key.
+
+* `access_secret` - (Optional) The registry access secret.
+
+* `credential_type` - (Optional) Credential type, such as 'basic', 'oauth'.
+
 ## Attributes Reference
 
 In addition to all argument, the following attributes are exported:

--- a/harbor/data_source_registry.go
+++ b/harbor/data_source_registry.go
@@ -41,6 +41,19 @@ func dataSourceRegistry() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"access_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"access_secret": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"credential_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 		Read: dataSourceRegistryRead,
 	}


### PR DESCRIPTION
### Description

We use external registries that require credentials. This PR is adding `access_key`, `access_secret` and `credential_type` to the `harbor_registry` resource so that such registries can be managed by terraform.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [X] Have you run the acceptance tests on this branch?

<!---
More informations about the Documentation process can be found at
https://nolte.github.io/terraform-provider-harbor/guides/development/#docs
--->
### Documentation
- [X] Have you create or updated the provider documentation at ``./documentation/provider_doc``?
  - [ ] If **new** resources or datasource documentation happen, did you add this to the `mkdocs.yml` configuration?

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
